### PR TITLE
Javascript validation and transparent rejection.

### DIFF
--- a/honeypot/decorators.py
+++ b/honeypot/decorators.py
@@ -5,7 +5,7 @@ except ImportError:
 
 from django.conf import settings
 from django.utils.safestring import mark_safe
-from django.http import HttpResponseBadRequest
+from django.http import HttpResponseBadRequest, HttpResponse
 from django.template.loader import render_to_string
 
 def honeypot_equals(val):

--- a/honeypot/decorators.py
+++ b/honeypot/decorators.py
@@ -31,7 +31,9 @@ def verify_honeypot_value(request, field_name):
     
     if request.method == 'POST':
         field = field_name or settings.HONEYPOT_FIELD_NAME
+        
         js_field = field + 'js'
+        failed_js_validation = False
         
         if use_js_field and js_field not in request.POST:
             failed_js_validation = True

--- a/honeypot/decorators.py
+++ b/honeypot/decorators.py
@@ -31,10 +31,9 @@ def verify_honeypot_value(request, field_name):
     
     if request.method == 'POST':
         field = field_name or settings.HONEYPOT_FIELD_NAME
+        js_field = field + '_js'
         
-        js_field = field + 'js'
         failed_js_validation = False
-        
         if use_js_field and js_field not in request.POST:
             failed_js_validation = True
         

--- a/honeypot/decorators.py
+++ b/honeypot/decorators.py
@@ -27,9 +27,17 @@ def verify_honeypot_value(request, field_name):
     """
     verifier = getattr(settings, 'HONEYPOT_VERIFIER', honeypot_equals)
     redirect = getattr(settings, 'HONEYPOT_REDIRECT_URL', None)
+    use_js_field = getattr(settings, 'HONEYPOT_USE_JS_FIELD', False)
+    
     if request.method == 'POST':
         field = field_name or settings.HONEYPOT_FIELD_NAME
-        if field not in request.POST or not verifier(request.POST[field]):
+        js_field = field + 'js'
+        
+        if use_js_field and js_field not in request.POST:
+            failed_js_validation = True
+        
+        if field not in request.POST or not verifier(request.POST[field]) or failed_js_validation:
+            
             #If a redirect url is specified in the settings, redirect user
             if redirect != None:
                 return HttpResponseRedirect(redirect)

--- a/honeypot/templates/honeypot/honeypot_error.html
+++ b/honeypot/templates/honeypot/honeypot_error.html
@@ -1,3 +1,3 @@
 <html xmlns="http://www.w3.org/1999/xhtml" xml:lang="en">
-    <body><h1>400 Bad Request</h1><p>Honey Pot Error ({{fieldname}}). Request aborted.</p></body>
+    <body><h1>Thanks for registering!</h1><p>Your account has been created.</p></body>
 </html>

--- a/honeypot/templates/honeypot/honeypot_error.html
+++ b/honeypot/templates/honeypot/honeypot_error.html
@@ -1,3 +1,3 @@
 <html xmlns="http://www.w3.org/1999/xhtml" xml:lang="en">
-    <body><h1>Thanks for registering!</h1><p>Your account has been created.</p></body>
+    <body><h1>400 Bad Request</h1><p>Honey Pot Error ({{fieldname}}). Request aborted.</p></body>
 </html>

--- a/honeypot/templates/honeypot/honeypot_field.html
+++ b/honeypot/templates/honeypot/honeypot_field.html
@@ -3,8 +3,9 @@
         <input id="{{fieldname}}" type="text" name="{{fieldname}}" value="{{value}}" />
     </label>
     {% if use_js_field %}
-    <script type="text/javascript">
+    {% if display_script_tags %}<script type="text/javascript">{% endif %}
         document.write('<input type="hidden" name="{{fieldname}}_js" value="1" />');
-    </script>
+    
+    {% if display_script_tags %}</script>{% endif %}
     {% endif %}
 </div>

--- a/honeypot/templates/honeypot/honeypot_field.html
+++ b/honeypot/templates/honeypot/honeypot_field.html
@@ -1,5 +1,10 @@
 <div style="display: none;">
     <label>leave this field blank to prove your humanity
-        <input type="text" name="{{fieldname}}" value="{{value}}" />
+        <input id="{{fieldname}}" type="text" name="{{fieldname}}" value="{{value}}" />
     </label>
+    {% if use_js_field %}
+    <script type="text/javascript">
+        document.write('<input type="hidden" name="{{fieldname}}_js" value="1" />');
+    </script>
+    {% endif %}
 </div>

--- a/honeypot/templatetags/honeypot.py
+++ b/honeypot/templatetags/honeypot.py
@@ -4,7 +4,7 @@ from django.conf import settings
 register = template.Library()
 
 @register.inclusion_tag('honeypot/honeypot_field.html')
-def render_honeypot_field(use_js_field = None, field_name=None):
+def render_honeypot_field(field_name=None):
     """
         Renders honeypot field named field_name (defaults to HONEYPOT_FIELD_NAME).
     """
@@ -14,9 +14,25 @@ def render_honeypot_field(use_js_field = None, field_name=None):
     if callable(value):
         value = value()
     
-    if use_js_field != None:
-        use_js_field = True if use_js_field == 'True' else False
-    else:
-        use_js_field = getattr(settings, 'HONEYPOT_USE_JS_FIELD', False)
+    use_js_field = getattr(settings, 'HONEYPOT_USE_JS_FIELD', False)
+    display_script_tags = True
     
     return {'fieldname': field_name, 'value': value, 'use_js_field': use_js_field}
+
+
+@register.inclusion_tag('honeypot/honeypot_field.html')
+def render_honeypot_field_js(field_name=None):
+    """
+        Renders honeypot field named field_name (defaults to HONEYPOT_FIELD_NAME).
+    """
+    if not field_name:
+        field_name = settings.HONEYPOT_FIELD_NAME
+    value = getattr(settings, 'HONEYPOT_VALUE', '')
+    if callable(value):
+        value = value()
+    
+    use_js_field = getattr(settings, 'HONEYPOT_USE_JS_FIELD', False)
+    display_script_tags = False
+    
+    return {'fieldname': field_name, 'value': value, 'display_script_tags': display_script_tags,
+        'use_js_field': use_js_field}

--- a/honeypot/templatetags/honeypot.py
+++ b/honeypot/templatetags/honeypot.py
@@ -4,7 +4,7 @@ from django.conf import settings
 register = template.Library()
 
 @register.inclusion_tag('honeypot/honeypot_field.html')
-def render_honeypot_field(field_name=None):
+def render_honeypot_field(use_js_field = None, field_name=None):
     """
         Renders honeypot field named field_name (defaults to HONEYPOT_FIELD_NAME).
     """
@@ -14,6 +14,9 @@ def render_honeypot_field(field_name=None):
     if callable(value):
         value = value()
     
-    use_js_field = getattr(settings, 'HONEYPOT_USE_JS_FIELD', False)
+    if use_js_field != None:
+        use_js_field = True if use_js_field == 'True' else False
+    else:
+        use_js_field = getattr(settings, 'HONEYPOT_USE_JS_FIELD', False)
     
     return {'fieldname': field_name, 'value': value, 'use_js_field': use_js_field}

--- a/honeypot/templatetags/honeypot.py
+++ b/honeypot/templatetags/honeypot.py
@@ -13,4 +13,7 @@ def render_honeypot_field(field_name=None):
     value = getattr(settings, 'HONEYPOT_VALUE', '')
     if callable(value):
         value = value()
-    return {'fieldname': field_name, 'value': value}
+    
+    use_js_field = getattr(settings, 'HONEYPOT_USE_JS_FIELD', False)
+    
+    return {'fieldname': field_name, 'value': value, 'use_js_field': use_js_field}


### PR DESCRIPTION
Hey,

Added a javascript validation, if turned on using settings, clients without javascript get treated as spam bots.

Also added a setting to make it transparent (redirect to a fake success page) instead of sending a http bad request. No need to let the spam bot know that it has been rejected. I think that's more aligned with the concept of a honeypot.

If you guys are interested...
