### PR TITLE
Use different style for field

### DIFF
--- a/honeypot/templates/honeypot/honeypot_field.html
+++ b/honeypot/templates/honeypot/honeypot_field.html
@@ -1,4 +1,4 @@
-<div style="display: none;">
+<div style="opacity: 0; position: absolute; top: 0; left: 0; height: 0; width: 0; z-index: -1;">
     <label>leave this field blank to prove your humanity
         <input type="text" name="{{fieldname}}" value="{{value}}" />
     </label>


### PR DESCRIPTION
Use different style than `display:none` for html field, since it can be detected by some bots.

Credits to [https://dev.to/felipperegazio/how-to-create-a-simple-honeypot-to-protect-your-web-forms-from-spammers--25n8](https://dev.to/felipperegazio/how-to-create-a-simple-honeypot-to-protect-your-web-forms-from-spammers--25n8)