### PR TITLE
Mark the honeypot field as non-autocomplete

### DIFF
--- a/honeypot/templates/honeypot/honeypot_field.html
+++ b/honeypot/templates/honeypot/honeypot_field.html
@@ -1,5 +1,5 @@
 <div style="opacity: 0; position: absolute; top: 0; left: 0; height: 0; width: 0; z-index: -1;">
     <label>leave this field blank to prove your humanity
-        <input type="text" name="{{fieldname}}" value="{{value}}" />
+        <input type="text" name="{{fieldname}}" value="{{value}}" autocomplete="off" />
     </label>
 </div>


### PR DESCRIPTION
Thanks for this package, it's been very useful.

I'm not sure if something has recently changed in Chrome, but we've had two clients report that users have been shown the honey pot error code when they use autofill on the forms. We use `zip_code` as our honeypot field name which is a common field on the web but not for our Australian based websites, seems like Chrome (and probably Edge by extension) is now autofilling this field when it's on the form, even if it's not visible.