### PR TITLE
Replace flake8 with ruff

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -22,13 +22,13 @@ jobs:
     # Python & dependency installation
     - uses: actions/checkout@v3
     - name: setup Python ${{ matrix.python-version }}
-      uses: actions/setup-python@v3
+      uses: actions/setup-python@v4
       with:
         python-version: ${{ matrix.python-version }}
     - name: install dependencies
-      run: pip install --pre Django==${{ matrix.django-version }} flake8 black
-    - name: lint with flake8
-      run: flake8 --show-source --statistics --ignore=E203,E501,W503
+      run: pip install black ruff --pre Django==${{ matrix.django-version }}
+    - name: lint with ruff
+      run: ruff --format=github .
     - name: lint with black
       run: black --check honeypot
     - name: run tests

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,14 +1,20 @@
 default_language_version:
     python: python3.9
+
 repos:
 -   repo: https://github.com/pre-commit/pre-commit-hooks
-    rev: v2.2.3
+    rev: v4.4.0
     hooks:
       - id: check-merge-conflict
       - id: debug-statements
-      - id: flake8
-        args: ['--max-line-length=120', '--ignore=E203,E501,W503']
+
+-   repo: https://github.com/charliermarsh/ruff-pre-commit
+    rev: v0.0.259
+    hooks:
+      - id: ruff
+        # args: [--fix, --exit-non-zero-on-fix]
+
 -   repo: https://github.com/ambv/black
-    rev: 20.8b1
+    rev: 23.1.0
     hooks:
       - id: black

--- a/honeypot/decorators.py
+++ b/honeypot/decorators.py
@@ -1,4 +1,5 @@
 from functools import wraps
+
 from django.conf import settings
 from django.http import HttpResponseBadRequest
 from django.template.loader import render_to_string
@@ -30,6 +31,7 @@ def verify_honeypot_value(request, field_name):
                 "honeypot/honeypot_error.html", {"fieldname": field}
             )
             return HttpResponseBadRequest(resp)
+    return None
 
 
 def check_honeypot(func=None, field_name=None):
@@ -46,10 +48,7 @@ def check_honeypot(func=None, field_name=None):
     def decorated(func):
         def inner(request, *args, **kwargs):
             response = verify_honeypot_value(request, field_name)
-            if response:
-                return response
-            else:
-                return func(request, *args, **kwargs)
+            return response or func(request, *args, **kwargs)
 
         return wraps(func)(inner)
 
@@ -66,6 +65,7 @@ def honeypot_exempt(view_func):
     """
     Mark view as exempt from honeypot validation
     """
+
     # borrowing liberally from django's csrf_exempt
     def wrapped(*args, **kwargs):
         return view_func(*args, **kwargs)

--- a/honeypot/middleware.py
+++ b/honeypot/middleware.py
@@ -1,8 +1,10 @@
 import re
-from django.utils.safestring import mark_safe
-from django.template.loader import render_to_string
+
 from django.conf import settings
+from django.template.loader import render_to_string
 from django.utils.encoding import force_str
+from django.utils.safestring import mark_safe
+
 from honeypot.decorators import verify_honeypot_value
 
 # these were moved out of Django 1.2 -- we're going to still use them

--- a/honeypot/tests.py
+++ b/honeypot/tests.py
@@ -1,10 +1,11 @@
-from django.test import TestCase
-from django.http import HttpRequest, HttpResponse, HttpResponseBadRequest
-from django.template import Template, Context
-from django.template.loader import render_to_string
 from django.conf import settings
-from honeypot.middleware import HoneypotViewMiddleware, HoneypotResponseMiddleware
-from honeypot.decorators import verify_honeypot_value, check_honeypot, honeypot_exempt
+from django.http import HttpRequest, HttpResponse, HttpResponseBadRequest
+from django.template import Context, Template
+from django.template.loader import render_to_string
+from django.test import TestCase
+
+from honeypot.decorators import check_honeypot, honeypot_exempt, verify_honeypot_value
+from honeypot.middleware import HoneypotResponseMiddleware, HoneypotViewMiddleware
 
 
 def _get_GET_request():
@@ -35,7 +36,7 @@ class VerifyHoneypotValue(HoneypotTestCase):
         """test that verify_honeypot_value is not called when request.method == GET"""
         request = _get_GET_request()
         resp = verify_honeypot_value(request, None)
-        self.assertEquals(resp, None)
+        self.assertEqual(resp, None)
 
     def test_verifier_false(self):
         """test that verify_honeypot_value fails when HONEYPOT_VERIFIER returns False"""
@@ -43,21 +44,21 @@ class VerifyHoneypotValue(HoneypotTestCase):
         request.POST[settings.HONEYPOT_FIELD_NAME] = ""
         settings.HONEYPOT_VERIFIER = lambda x: False
         resp = verify_honeypot_value(request, None)
-        self.assertEquals(resp.__class__, HttpResponseBadRequest)
+        self.assertEqual(resp.__class__, HttpResponseBadRequest)
 
     def test_field_missing(self):
         """test that verify_honeypot_value succeeds when HONEYPOT_FIELD_NAME is missing from
         request.POST"""
         request = _get_POST_request()
         resp = verify_honeypot_value(request, None)
-        self.assertEquals(resp.__class__, HttpResponseBadRequest)
+        self.assertEqual(resp.__class__, HttpResponseBadRequest)
 
     def test_field_blank(self):
         """test that verify_honeypot_value succeeds when HONEYPOT_VALUE is blank"""
         request = _get_POST_request()
         request.POST[settings.HONEYPOT_FIELD_NAME] = ""
         resp = verify_honeypot_value(request, None)
-        self.assertEquals(resp, None)
+        self.assertEqual(resp, None)
 
     def test_honeypot_value_string(self):
         """test that verify_honeypot_value succeeds when HONEYPOT_VALUE is a string"""
@@ -65,7 +66,7 @@ class VerifyHoneypotValue(HoneypotTestCase):
         settings.HONEYPOT_VALUE = "(test string)"
         request.POST[settings.HONEYPOT_FIELD_NAME] = settings.HONEYPOT_VALUE
         resp = verify_honeypot_value(request, None)
-        self.assertEquals(resp, None)
+        self.assertEqual(resp, None)
 
     def test_honeypot_value_callable(self):
         """test that verify_honeypot_value succeeds when HONEYPOT_VALUE is a callable"""
@@ -73,7 +74,7 @@ class VerifyHoneypotValue(HoneypotTestCase):
         settings.HONEYPOT_VALUE = lambda: "(test string)"
         request.POST[settings.HONEYPOT_FIELD_NAME] = settings.HONEYPOT_VALUE()
         resp = verify_honeypot_value(request, None)
-        self.assertEquals(resp, None)
+        self.assertEqual(resp, None)
 
 
 class CheckHoneypotDecorator(HoneypotTestCase):
@@ -82,14 +83,14 @@ class CheckHoneypotDecorator(HoneypotTestCase):
         new_view_func = check_honeypot(view_func)
         request = _get_POST_request()
         resp = new_view_func(request)
-        self.assertEquals(resp.__class__, HttpResponseBadRequest)
+        self.assertEqual(resp.__class__, HttpResponseBadRequest)
 
     def test_decorator_argument(self):
         """test that check_honeypot(view, 'fieldname') works"""
         new_view_func = check_honeypot(view_func, "fieldname")
         request = _get_POST_request()
         resp = new_view_func(request)
-        self.assertEquals(resp.__class__, HttpResponseBadRequest)
+        self.assertEqual(resp.__class__, HttpResponseBadRequest)
 
     def test_decorator_py24_syntax(self):
         """test that @check_honeypot syntax works"""
@@ -100,7 +101,7 @@ class CheckHoneypotDecorator(HoneypotTestCase):
 
         request = _get_POST_request()
         resp = new_view_func(request)
-        self.assertEquals(resp.__class__, HttpResponseBadRequest)
+        self.assertEqual(resp.__class__, HttpResponseBadRequest)
 
 
 class RenderHoneypotField(HoneypotTestCase):
@@ -109,7 +110,7 @@ class RenderHoneypotField(HoneypotTestCase):
             "honeypot/honeypot_field.html", {"fieldname": fieldname, "value": value}
         )
         rendered = template.render(Context())
-        self.assertEquals(rendered, correct)
+        self.assertEqual(rendered, correct)
 
     def test_default_templatetag(self):
         """test that {% render_honeypot_field %} works and defaults to HONEYPOT_FIELD_NAME"""
@@ -133,7 +134,6 @@ class RenderHoneypotField(HoneypotTestCase):
 
 
 class HoneypotMiddleware(HoneypotTestCase):
-
     _response_body = '<form method="POST"></form>'
 
     def test_view_middleware_invalid(self):
@@ -142,7 +142,7 @@ class HoneypotMiddleware(HoneypotTestCase):
         retval = HoneypotViewMiddleware(lambda request: None).process_view(
             request, view_func, (), {}
         )
-        self.assertEquals(retval.__class__, HttpResponseBadRequest)
+        self.assertEqual(retval.__class__, HttpResponseBadRequest)
 
     def test_view_middleware_valid(self):
         """call view when HONEYPOT_VERIFIER returns True"""
@@ -151,7 +151,7 @@ class HoneypotMiddleware(HoneypotTestCase):
         retval = HoneypotViewMiddleware(lambda request: None).process_view(
             request, view_func, (), {}
         )
-        self.assertEquals(retval, None)
+        self.assertEqual(retval, None)
 
     def test_response_middleware_rewrite(self):
         """ensure POST forms are rewritten"""
@@ -187,4 +187,4 @@ class HoneypotMiddleware(HoneypotTestCase):
         retval = HoneypotViewMiddleware(lambda request: None).process_view(
             request, exempt_view_func, (), {}
         )
-        self.assertEquals(retval, None)
+        self.assertEqual(retval, None)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -21,15 +21,65 @@ classifiers = [
     "Environment :: Web Environment",
 ]
 
-
 [tool.poetry.dependencies]
-python = "^3.7"
 Django = ">=2.2,<5.0"
+python = "^3.7"
 
 [tool.poetry.dev-dependencies]
-flake8 = "^3.9.2"
-black = "^22.8"
+black = "^23.1.0"
+ruff = "^0.0.259"
 
 [build-system]
 requires = ["poetry-core>=1.0.0"]
 build-backend = "poetry.core.masonry.api"
+
+[tool.ruff]
+select = [
+    "A",
+    "B",
+    "BLE",
+    "C4",
+    "C90",
+    "DJ",
+    "DTZ",
+    "E",
+    "EM",
+    "ERA",
+    "EXE",
+    "F",
+    "FBT",
+    "G",
+    "I",
+    "ICN",
+    "INP",
+    "ISC",
+    "N",
+    "NPY",
+    "PD",
+    "PGH",
+    "PIE",
+    "PL",
+    "PTH",
+    "PYI",
+    "Q",
+    "RSE",
+    "RUF",
+    "S",
+    "SIM",
+    "SLF",
+    "T10",
+    "T20",
+    "TCH",
+    "TID",
+    "TRY",
+    "UP",
+    "W",
+    "YTT"
+]
+line-length = 93
+target-version = "py37"
+
+[tool.ruff.per-file-ignores]
+"honeypot/middleware.py" = ["S308"]
+"honeypot/tests.py" = ["N802"]
+"test*" = ["S101", "S105"]

--- a/tox.ini
+++ b/tox.ini
@@ -1,17 +1,14 @@
 [tox]
-envlist = py37-django{22,30}, flake8
+envlist = py3{10,11}-django{40,41}, ruff
 
-[testenv:flake8]
-deps = flake8
-commands = flake8 --ignore=E402,E731 honeypot
+[testenv:ruff]
+deps = ruff
+commands = ruff --show-fixes --show-source .
 
 [testenv]
 deps =
-    django22: Django==2.2
-    django30: Django==3.0rc1
+    django40: Django==4.0
+    django41: Django==4.1
 commands =
     django-admin.py test --settings test_settings --pythonpath=.
 pip_pre = True
-
-[flake8]
-max-line-length=99


### PR DESCRIPTION
[Ruff](https://beta.ruff.rs/) supports [over 500 lint rules](https://beta.ruff.rs/docs/rules) and can be used to replace [Flake8](https://pypi.org/project/flake8/) (plus dozens of plugins), [isort](https://pypi.org/project/isort/), [pydocstyle](https://pypi.org/project/pydocstyle/), [yesqa](https://github.com/asottile/yesqa), [eradicate](https://pypi.org/project/eradicate/), [pyupgrade](https://pypi.org/project/pyupgrade/), and [autoflake](https://pypi.org/project/autoflake/), all while executing (in Rust) tens or hundreds of times faster than any individual tool.

Running `ruff --format=github .` in GitHub Actions will rapidly provide intuitive GitHub Annotations to contributors.

![image](https://user-images.githubusercontent.com/3709715/223758136-afc386d2-70aa-4eff-953a-2c2d82ceea23.png)