### PR TITLE
GitHub Actions: Add Django v5.0 to the testing

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -14,10 +14,12 @@ jobs:
       max-parallel: 4
       matrix:
         python-version: ['3.8', '3.12']
-        django-version: [3.2, 4.2]
+        django-version: [3.2, 4.2, 5.0]
         exclude:
           - python-version: "3.12"
             django-version: "3.2"
+          - python-version: "3.8"
+            django-version: "5.0"
     steps:
     # Python & dependency installation
     - uses: actions/checkout@v4
@@ -28,7 +30,7 @@ jobs:
     - name: install dependencies
       run: pip install black ruff --pre Django==${{ matrix.django-version }}
     - name: lint with ruff
-      run: ruff --output-format=github .
+      run: ruff --output-format=github
     - name: lint with black
       run: black --check honeypot
     - name: run tests

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -18,11 +18,12 @@ classifiers = [
     "Framework :: Django :: 4.0",
     "Framework :: Django :: 4.1",
     "Framework :: Django :: 4.2",
+    "Framework :: Django :: 5.0",
     "Environment :: Web Environment",
 ]
 
 [tool.poetry.dependencies]
-Django = ">=3.2,<5.0"
+Django = ">=3.2,<5.1"
 python = "^3.8"
 
 [tool.poetry.dev-dependencies]


### PR DESCRIPTION
https://pypi.org/project/Django

https://www.djangoproject.com/weblog/2023/dec/04/django-50-released

> Django 4.1 has reached the end of extended support. The final security release ([4.1.13](https://docs.djangoproject.com/en/stable/releases/4.1.13/)) was issued on November 1st. All Django 4.1 users are encouraged to [upgrade](https://docs.djangoproject.com/en/dev/howto/upgrade-version/) to Django 4.2 or later.

https://docs.djangoproject.com/en/5.0/releases/5.0
> Django 5.0 supports Python 3.10, 3.11, and 3.12.