### PR TITLE
Add system check for correct middleware

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -92,7 +92,7 @@ All of these middleware live in ``honeypot.middleware``.
 
 ``HoneypotViewMiddleware`` ensures that for all incoming POST requests to views ``request.POST`` contains a valid honeypot field as defined by the ``HONEYPOT_FIELD_NAME``, ``HONEYPOT_VALUE``, and ``HONEYPOT_VERIFIER`` settings.  The result is the same as if every view in your project were decorated with ``@check_honeypot``.
 
-``HoneypotMiddleware`` is a combined middleware that applies both ``HoneypotResponseMiddleware`` and ``HoneypotViewMiddleware``, this is the easiest way to get honeypot fields site-wide and can be used in many if not most cases.
+``HoneypotMiddleware`` is a combined middleware that applies both ``HoneypotResponseMiddleware`` and ``HoneypotViewMiddleware``, this is the easiest way to get honeypot fields site-wide and can be used in many if not most cases. The middleware needs to be listed after ``CommonMiddleware`` because the middleware changes the response. If you list it before  ``CommonMiddleware`` then the ``Content-Length`` header won't reflect the changes.
 
 Customizing honeypot display
 ----------------------------

--- a/honeypot/apps.py
+++ b/honeypot/apps.py
@@ -1,0 +1,11 @@
+from django.apps import AppConfig
+from django.core import checks
+
+from honeypot.checks import check_middleware_order
+
+
+class HoneypotConfig(AppConfig):
+    name = "honeypot"
+
+    def ready(self):
+        checks.register(check_middleware_order)

--- a/honeypot/checks.py
+++ b/honeypot/checks.py
@@ -1,0 +1,27 @@
+from django.conf import settings
+from django.core.checks import Error
+
+
+def check_middleware_order(app_configs, **kwargs):
+    middleware = list(settings.MIDDLEWARE)
+    if "django.middleware.common.CommonMiddleware" not in middleware:
+        return []
+
+    if "honeypot.middleware.HoneypotMiddleware" in middleware:
+        honeypot_index = middleware.index("honeypot.middleware.HoneypotMiddleware")
+    elif "honeypot.middleware.HoneypotResponseMiddleware" in middleware:
+        honeypot_index = middleware.index(
+            "honeypot.middleware.HoneypotResponseMiddleware"
+        )
+    else:
+        return []
+
+    if honeypot_index < middleware.index("django.middleware.common.CommonMiddleware"):
+        return [
+            Error(
+                "The honeypot middleware needs to be listed after CommonMiddleware",
+                id="honeypot.E001",
+            ),
+        ]
+
+    return []

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py3{10,11}-django{40,41}, ruff
+envlist = py3{10,11,12}-django{42,50}, ruff
 
 [testenv:ruff]
 deps = ruff
@@ -10,5 +10,5 @@ deps =
     django40: Django==4.0
     django41: Django==4.1
 commands =
-    django-admin.py test --settings test_settings --pythonpath=.
+    django-admin test --settings test_settings --pythonpath=.
 pip_pre = True


### PR DESCRIPTION
If the honeypot middleware is installed before CommonMiddleware you will get a wrong Content-Length header because CommonMiddleware has computed the length on the wrong content. This causes hard to debug issues. This PR add a system check to prevent this from happening and documents in the README that you need to list the middleware after CommonMiddleware.

It also fixes and updates tox.ini.