### PR TITLE
Add HONEYPOT_RESPONDER setting for custom error handling and response

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -106,3 +106,23 @@ There are two templates used by django-honeypot that can be used to control vari
 ``honeypot/honeypot_error.html`` is the error page rendered when a bad request is intercepted.  It is given the context variable ``fieldname`` representing the name of the honeypot field.
 
 To completely change the error page or what happens when a bad request is intercepted set ``HONEYPOT_RESPONDER`` to a function accepting ``request`` and ``context`` kwargs and returning a ``HttpResponse``.
+
+.. code:: python
+
+    # mypackage.py
+    from honeypot.decorators import honeypot_error
+
+    def custom_honeypot_error(request, context):
+        # custom responder logging the event
+        log.warning("gotcha!")
+        # call built-in responder to send default HttpResponseBadRequest
+        return honeypot_error(request, context)
+        # or ...
+        # raise Http404
+
+.. code:: python
+
+    # settings.py
+    from django.utils.module_loading import import_string
+
+    HONEYPOT_RESPONDER = import_string('mypackage.custom_honeypot_error')

--- a/README.rst
+++ b/README.rst
@@ -35,6 +35,8 @@ You will almost always need to define ``HONEYPOT_FIELD_NAME`` which is the name 
 
 ``HONEYPOT_VERIFIER`` is an advanced option that you can specify to validate the honeypot.  The default verifier ensures that the contents of the honeypot field matches ``HONEYPOT_VALUE``.  Using a combination of a callable for ``HONEYPOT_VALUE`` and ``HONEYPOT_VERIFIER`` it is possible to implement a more advanced technique such as using timestamps.
 
+``HONEYPOT_RESPONDER`` can be used to replace the default response in case of an invalid honeypot.
+
 Adding honeypot fields to specific forms and views
 --------------------------------------------------
 
@@ -73,10 +75,10 @@ The same as above for `Adding honeypot fields to specific forms and views`_ but 
 
 
 .. code:: python
-    
+
     from django.utils.decorators import method_decorator
     from honeypot.decorators import check_honeypot
-    
+
     @method_decorator(check_honeypot, name='post')
     class MyView(FormView):
         ...
@@ -103,3 +105,4 @@ There are two templates used by django-honeypot that can be used to control vari
 
 ``honeypot/honeypot_error.html`` is the error page rendered when a bad request is intercepted.  It is given the context variable ``fieldname`` representing the name of the honeypot field.
 
+To completely change the error page or what happens when a bad request is intercepted set ``HONEYPOT_RESPONDER`` to a function accepting ``request`` and ``context`` kwargs and returning a ``HttpResponse``.

--- a/honeypot/decorators.py
+++ b/honeypot/decorators.py
@@ -18,7 +18,8 @@ def honeypot_equals(val):
 
 def honeypot_error(request, context):
     """
-    Return error response for invalid honeypot.
+    Default responder used if HONEYPOT_RESPONDER is not specified.
+    Return HttpResponseBadRequest for invalid honeypot.
     """
     resp = render_to_string(
         "honeypot/honeypot_error.html",

--- a/honeypot/decorators.py
+++ b/honeypot/decorators.py
@@ -16,6 +16,18 @@ def honeypot_equals(val):
     return val == expected
 
 
+def honeypot_error(request, context):
+    """
+    Return error response for invalid honeypot.
+    """
+    resp = render_to_string(
+        "honeypot/honeypot_error.html",
+        context=context,
+        request=request,
+    )
+    return HttpResponseBadRequest(resp)
+
+
 def verify_honeypot_value(request, field_name):
     """
     Verify that request.POST[field_name] is a valid honeypot.
@@ -24,15 +36,11 @@ def verify_honeypot_value(request, field_name):
     HONEYPOT_VERIFIER.
     """
     verifier = getattr(settings, "HONEYPOT_VERIFIER", honeypot_equals)
+    responder = getattr(settings, "HONEYPOT_RESPONDER", honeypot_error)
     if request.method == "POST":
         field = field_name or settings.HONEYPOT_FIELD_NAME
         if field not in request.POST or not verifier(request.POST[field]):
-            resp = render_to_string(
-                "honeypot/honeypot_error.html",
-                {"fieldname": field},
-                request=request,
-            )
-            return HttpResponseBadRequest(resp)
+            return responder(request, {"fieldname": field})
     return None
 
 

--- a/honeypot/tests.py
+++ b/honeypot/tests.py
@@ -49,7 +49,7 @@ class VerifyHoneypotValue(HoneypotTestCase):
         self.assertEqual(resp.__class__, HttpResponseBadRequest)
 
     def test_field_missing(self):
-        """test that verify_honeypot_value succeeds when HONEYPOT_FIELD_NAME is missing from
+        """test that verify_honeypot_value fails when HONEYPOT_FIELD_NAME is missing from
         request.POST"""
         request = _get_POST_request()
         resp = verify_honeypot_value(request, None)
@@ -63,7 +63,8 @@ class VerifyHoneypotValue(HoneypotTestCase):
         self.assertEqual(resp, None)
 
     def test_honeypot_value_string(self):
-        """test that verify_honeypot_value succeeds when HONEYPOT_VALUE is a string"""
+        """test that verify_honeypot_value succeeds when HONEYPOT_VALUE is the expected
+        string"""
         request = _get_POST_request()
         settings.HONEYPOT_VALUE = "(test string)"
         request.POST[settings.HONEYPOT_FIELD_NAME] = settings.HONEYPOT_VALUE
@@ -71,7 +72,8 @@ class VerifyHoneypotValue(HoneypotTestCase):
         self.assertEqual(resp, None)
 
     def test_honeypot_value_callable(self):
-        """test that verify_honeypot_value succeeds when HONEYPOT_VALUE is a callable"""
+        """test that verify_honeypot_value succeeds when HONEYPOT_VALUE is the expected
+        return value of a callable"""
         request = _get_POST_request()
         settings.HONEYPOT_VALUE = lambda: "(test string)"
         request.POST[settings.HONEYPOT_FIELD_NAME] = settings.HONEYPOT_VALUE()


### PR DESCRIPTION
Hi! Thanks for this small, "no bs" package to easily add a honeypot. :)

I had two requirements:
- send a signal or log when someone taps the honeypot
- just respond with a plain error response

Both could be fulfilled without much changes to the library, by adding another setting to override the function used to generate the response.

This PR does just that:
- move the default `HttpResponseBadRequest` using "/honeypot/honeypot_error.html" code to a separate function
- add `HONEYPOT_RESPONDER` setting to override said function

Example usage:

```python
# utils.py or views.py or something
from honeypot.decorators import honeypot_error

def custom_honeypot_error(request, context):
    log.warning("gotcha!")
    # call built-in responder after all
    return honeypot_error(request, context)
    # or ...
    # raise Http404
```

```python
# settings.py
from django.utils.module_loading import import_string

HONEYPOT_RESPONDER = import_string('mypackage.custom_honeypot_error')
```

