### PR TITLE
pre-commit autoupdate 2024-08-02

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -3,18 +3,18 @@ default_language_version:
 
 repos:
 -   repo: https://github.com/pre-commit/pre-commit-hooks
-    rev: v4.5.0
+    rev: v4.6.0
     hooks:
       - id: check-merge-conflict
       - id: debug-statements
 
 -   repo: https://github.com/charliermarsh/ruff-pre-commit
-    rev: v0.1.7
+    rev: v0.5.5
     hooks:
       - id: ruff
         # args: [--fix, --exit-non-zero-on-fix]
 
 -   repo: https://github.com/ambv/black
-    rev: 23.11.0
+    rev: 24.4.2
     hooks:
       - id: black


### PR DESCRIPTION
% `pre-commit autoupdate`
```
[https://github.com/pre-commit/pre-commit-hooks] updating v4.5.0 -> v4.6.0
[https://github.com/charliermarsh/ruff-pre-commit] updating v0.1.7 -> v0.5.5
[https://github.com/ambv/black] updating 23.11.0 -> 24.4.2
```
% `pre-commit run --all-files`
```
check for merge conflicts................................................Passed
debug statements (python)................................................Passed
ruff.....................................................................Passed
black....................................................................Passed
````
Was it intentional to disable all the ruff rules in https://github.com/jamesturk/django-honeypot/commit/424c85dbe4bac132f66925fc4c119953950d793a ?

Should we upgrade from psf/black to ruff format?